### PR TITLE
Feat: CategoryPage, DetailPage페이지 렌더링 (fetchPostsData함수를 사용해 티켓 판매글 데이터를 postsDataState에 recoil로 관리)

### DIFF
--- a/src/components/Router.jsx
+++ b/src/components/Router.jsx
@@ -25,6 +25,8 @@ export default function Router() {
 
       {/* `${apiServer}/members/${userId}` */}
       <Route path="/auth/kakao/callback" element={<KakaoRedirect />} />
+
+      
       {/* 유저전용 */}
       {/* <Route element={<ProtectedRoute />}> */}
       <Route path="/" element={<MainPage />} />


### PR DESCRIPTION
[작업내용]
-기존에 MainPage에 있던 formatDate함수를 utils 폴더에 따로 만들었습니다.
-Router 설정 (DetailPage에 대해 동적 라우팅 설정: (/detail/:salePostId) 동적 경로에서의 salePostId값은, 해당 티켓 객체의 salePostId속성과 동일합니다.)
-fetchPostsData함수(티켓 판매글을 axios.get)를 사용해 티켓 판매글 데이터를 postsDataState에 recoil로 관리했습니다.
MainPage에서는  postsDataState를 그대로 가져와서 렌더링해주고, CategoryPage에서는 불러온  postsDataState를 해당 주소에 적혀있는 category에 맞게 필터링하여 보여줍니다.
-DetailPage는 MainPage,CategoryPage에서 해당 티켓을 누르면 바로 해당 티켓글로 이동할 수 있습니다. (Link컴포넌트 사용)


* socket.io-client 라이브러리 설치했습니다.
* 찜하기 기능 보류했습니다.