### PR TITLE
KakaoRedirect페이지에서 response2에 대한 요청 보낼 때 body의 email뒤에 띄어쓰기

### DIFF
--- a/src/pages/login/KakaoRedirect.jsx
+++ b/src/pages/login/KakaoRedirect.jsx
@@ -28,7 +28,7 @@ export default function KakaoRedirect() {
         const response2 = await axios.post(
           "https://oriticket.link/members/signin",
           {
-            email: response1.data.email,
+            email : response1.data.email,
           }
         );
 


### PR DESCRIPTION
KakaoRedirect페이지에서 response2에 대한 요청 보낼 때 body의 email뒤에 띄어쓰기했습니다.
```
const response1 = await axios.get(
          `https://oriticket.link/members/kakao/login?code=${code}`
        );
        console.log("인가코드 제대로 보내졌고, response 받음", response1);

        const response2 = await axios.post(
          "https://oriticket.link/members/signin",
          {
            email : response1.data.email,
          }
        );
```