### PR TITLE
 [ProfilePage.jsx] 회원탈퇴기능 api 연동 확인 위해, memberId를 18로  고정해놓았습니다.

### DIFF
--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -107,7 +107,7 @@ export default function ProfilePage() {
   const [soldoutTickets, setSoldoutTickets] = useState([]);
 
   // 사용자의 ID
-  const [memberId, setMemberId] = useState("7");
+  const [memberId, setMemberId] = useState("18");
   // const memberId = "1"; // memberId를 사용자의 실제 ID로 대체
 
 


### PR DESCRIPTION
 [ProfilePage.jsx] 회원탈퇴기능 api 연동 확인 위해, memberId를 18로
 고정해놓았습니다.